### PR TITLE
Fix height problem on select multiple

### DIFF
--- a/views/Form/bulma_0_3_x_layout.html.twig
+++ b/views/Form/bulma_0_3_x_layout.html.twig
@@ -30,8 +30,9 @@
         {%- for size in ['is-small', 'is-medium', 'is-large'] if size in form.vars.attr.class|default('') -%}
             {%- set size_class = size -%}
         {%- endfor -%}
+        {%- set is_multiple_class = multiple ? ' is-multiple' : '' -%}
         <div {{ block('form_widget_container_attributes') }}>
-        <span class="{{ ('select ' ~ size_class)|trim }}">
+        <span class="{{ ('select ' ~ size_class ~ is_multiple_class)|trim }}">
             {{- parent() -}}
         </span>
             {{- block('form_errors') -}}


### PR DESCRIPTION
If the `select` tag has the `multiple` attribute, the `span.select` does not receive the `is-multiple` class. It generates problem with the height of the list and next fields overlap the list.
![screenshot_2018-07-04 screenshot](https://user-images.githubusercontent.com/35693726/42277167-b7f044ea-7f96-11e8-8610-80e4324394e1.png)
